### PR TITLE
fix Nest can't resolve dependencies

### DIFF
--- a/src/items/items.module.ts
+++ b/src/items/items.module.ts
@@ -8,5 +8,6 @@ import { ItemSchema } from './schemas/item.schema';
   imports: [MongooseModule.forFeature([{ name: 'Item', schema: ItemSchema }])],
   controllers: [ItemsController],
   providers: [ItemsService],
+  exports: [MongooseModule.forFeature([{ name: 'Item', schema: ItemSchema }])],
 })
 export class ItemsModule {}


### PR DESCRIPTION
 ERROR: Nest can't resolve dependencies of the ItemsService (?). Please make sure that the argument at index [0] is available in the AppModule context.